### PR TITLE
Cache invalidation doesn't work when changing site assignments

### DIFF
--- a/dbtemplates/models.py
+++ b/dbtemplates/models.py
@@ -8,7 +8,8 @@ from django.contrib.sites.models import Site
 from django.contrib.sites.managers import CurrentSiteManager
 
 from dbtemplates.conf import settings
-from dbtemplates.utils.cache import add_template_to_cache, remove_cached_template
+from dbtemplates.utils.cache import (add_template_to_cache, remove_cached_template,
+                                     invalidate_cache_for_sites)
 from dbtemplates.utils.template import get_template_source
 
 try:
@@ -84,3 +85,5 @@ def add_default_site(instance, **kwargs):
 signals.post_save.connect(add_default_site, sender=Template)
 signals.post_save.connect(add_template_to_cache, sender=Template)
 signals.pre_delete.connect(remove_cached_template, sender=Template)
+signals.m2m_changed.connect(invalidate_cache_for_sites,
+                            sender=Template.sites.through)


### PR DESCRIPTION
When changing template-site assignments, invalidate cached templates that belonged to sites that got unassigned