### PR TITLE
Adjust autopopulate so that it works in an expected fashion with loaders that wrap dbtemplates

### DIFF
--- a/dbtemplates/conf.py
+++ b/dbtemplates/conf.py
@@ -14,6 +14,7 @@ class DbTemplatesConf(AppConf):
     AUTO_POPULATE_CONTENT = True
     MEDIA_PREFIX = None
     CACHE_BACKEND = None
+    SUBLOADER_NAME = 'loaders'
 
     def configure_media_prefix(self, value):
         if value is None:

--- a/dbtemplates/conf.py
+++ b/dbtemplates/conf.py
@@ -14,7 +14,12 @@ class DbTemplatesConf(AppConf):
     AUTO_POPULATE_CONTENT = True
     MEDIA_PREFIX = None
     CACHE_BACKEND = None
-    SUBLOADER_NAME = 'loaders'
+    TEMPLATE_LOADERS = None
+
+    def configure_template_loaders(self, value):
+        if value is None:
+            value = getattr(settings, "TEMPLATE_LOADERS", [])
+        return value
 
     def configure_media_prefix(self, value):
         if value is None:

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -18,12 +18,21 @@ def get_loaders():
         from django.template.loader import template_source_loaders
     return template_source_loaders or []
 
+def skip_loader(loader, pattern):
+   if loader.__module__.startswith(pattern):
+       return True
+   if hasattr(loader, 'loaders'): 
+       for subloader in loader.loaders:
+           return skip_loader(subloader, pattern)
+       return False
+   return False 
 
 def get_template_source(name):
     source = None
     for loader in get_loaders():
-        if loader.__module__.startswith('dbtemplates.'):
-            # Don't give a damn about dbtemplates' own loader.
+        if skip_loader(loader, 'dbtemplates.'):
+            # Don't give a damn about dbtemplates' own loader or loaders 
+            # that use the dbtemplates loader
             continue
         module = import_module(loader.__module__)
         load_template_source = getattr(module, 'load_template_source', None)

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -8,6 +8,7 @@ from dbtemplates.conf import settings
 DBTEMPLATES_TEMPLATE_LOADERS = settings.DBTEMPLATES_TEMPLATE_LOADERS
 loader_cache = None
 
+
 def get_loaders():
     global loader_cache
     if loader_cache is not None:
@@ -18,6 +19,7 @@ def get_loaders():
         if loader is not None:
             loader_cache.append(loader)
     return loader_cache
+
 
 def get_template_source(name):
     source = None

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -21,23 +21,25 @@ def get_loaders():
         from django.template.loader import template_source_loaders
     return template_source_loaders or []
 
+
 def skip_loader(loader, pattern):
-   if loader.__module__.startswith(pattern):
-       return True
-   if hasattr(loader, SUBLOADER_NAME): 
-       subloaders = getattr(loader, SUBLOADER_NAME)
-       if type(subloaders) is not list:
-           subloaders = [subloaders]
-       for subloader in subloaders:
-           return skip_loader(subloader, pattern)
-       return False
-   return False 
+    if loader.__module__.startswith(pattern):
+        return True
+    if hasattr(loader, SUBLOADER_NAME):
+        subloaders = getattr(loader, SUBLOADER_NAME)
+        if type(subloaders) is not list:
+            subloaders = [subloaders]
+        for subloader in subloaders:
+            return skip_loader(subloader, pattern)
+        return False
+    return False
+
 
 def get_template_source(name):
     source = None
     for loader in get_loaders():
         if skip_loader(loader, 'dbtemplates.'):
-            # Don't give a damn about dbtemplates' own loader or loaders 
+            # Don't give a damn about dbtemplates' own loader or loaders
             # that use the dbtemplates loader
             continue
         module = import_module(loader.__module__)

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -2,6 +2,9 @@ from django import VERSION
 from django.template import (Template, TemplateDoesNotExist,
                              TemplateSyntaxError)
 from django.utils.importlib import import_module
+from dbtemplates.conf import settings
+
+SUBLOADER_NAME = settings.DBTEMPLATES_SUBLOADER_NAME
 
 
 def get_loaders():
@@ -21,8 +24,11 @@ def get_loaders():
 def skip_loader(loader, pattern):
    if loader.__module__.startswith(pattern):
        return True
-   if hasattr(loader, 'loaders'): 
-       for subloader in loader.loaders:
+   if hasattr(loader, SUBLOADER_NAME): 
+       subloaders = getattr(loader, SUBLOADER_NAME)
+       if type(subloaders) is not list:
+           subloaders = [subloaders]
+       for subloader in subloaders:
            return skip_loader(subloader, pattern)
        return False
    return False 

--- a/dbtemplates/utils/template.py
+++ b/dbtemplates/utils/template.py
@@ -1,44 +1,28 @@
 from django import VERSION
 from django.template import (Template, TemplateDoesNotExist,
                              TemplateSyntaxError)
+from django.template.loader import find_template_loader
 from django.utils.importlib import import_module
 from dbtemplates.conf import settings
 
-SUBLOADER_NAME = settings.DBTEMPLATES_SUBLOADER_NAME
-
+DBTEMPLATES_TEMPLATE_LOADERS = settings.DBTEMPLATES_TEMPLATE_LOADERS
+loader_cache = None
 
 def get_loaders():
-    from django.template.loader import template_source_loaders
-    if template_source_loaders is None:
-        try:
-            from django.template.loader import find_template as finder
-        except ImportError:
-            from django.template.loader import find_template_source as finder  # noqa
-        try:
-            source, name = finder('test')
-        except TemplateDoesNotExist:
-            pass
-        from django.template.loader import template_source_loaders
-    return template_source_loaders or []
-
-
-def skip_loader(loader, pattern):
-    if loader.__module__.startswith(pattern):
-        return True
-    if hasattr(loader, SUBLOADER_NAME):
-        subloaders = getattr(loader, SUBLOADER_NAME)
-        if type(subloaders) is not list:
-            subloaders = [subloaders]
-        for subloader in subloaders:
-            return skip_loader(subloader, pattern)
-        return False
-    return False
-
+    global loader_cache
+    if loader_cache is not None:
+        return loader_cache
+    loader_cache = []
+    for loader_name in DBTEMPLATES_TEMPLATE_LOADERS:
+        loader = find_template_loader(loader_name)
+        if loader is not None:
+            loader_cache.append(loader)
+    return loader_cache
 
 def get_template_source(name):
     source = None
     for loader in get_loaders():
-        if skip_loader(loader, 'dbtemplates.'):
+        if loader.__module__.startswith('dbtemplates.'):
             # Don't give a damn about dbtemplates' own loader or loaders
             # that use the dbtemplates loader
             continue

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -22,6 +22,13 @@ To disable this feature set ``DBTEMPLATES_AUTO_POPULATE_CONTENT`` to
 The dotted Python path to the cache backend class. See
 :ref:`Caching <caching>` for details.
 
+``DBTEMPLATES_TEMPLATE_LOADERS``
+--------------------------------
+
+A tuple of Template loaders that dbtemplates should use when trying to
+autopopulate dbtemplates from the database.  Set to the value of 
+``settings.TEMPLATE_LOADERS`` by default.
+
 ``DBTEMPLATES_USE_CODEMIRROR``
 ------------------------------
 


### PR DESCRIPTION
I noticed that when using dbtemplates with pyjade.ext.django.loader (https://github.com/syrusakbary/pyjade/blob/master/pyjade/ext/django/loader.py) that the admin auto-populate functionality was not working as expected.  Clearing the template and saving did not cause the template to be correctly loaded from disk.  Instead, the empty template was saved.

Upon investigation, I discovered that although dbtemplates ignores its own loader when populating the template, if it calls a loader that wraps the dbtemplates loader, that loader will use the dbtemplates loader and return the empty template that was just saved with dbtemplates.

This pull request attempts to fix this by inspecting the loader to see

* If the template loader is from DB templates or
* If the template loader has any subloaders of its own and 
    * If any of those template loaders are dbtemplates

If any of those are true, then the template loader will be skipped.

The major downside of this approach is that we need to know something about the internal structure of the subloader (what if there's only one subloader in the wrapper?  What if the list of subloaders is called something other than "loaders"?)

This pull request tries to mitigate this by putting the knowledge about the submodule into the AppConfig and providing sensible defaults.